### PR TITLE
Propose Bamboo as the company standard for absences

### DIFF
--- a/guidelines/absences.md
+++ b/guidelines/absences.md
@@ -4,24 +4,32 @@ Everyone affected by your absence needs to be able to easily understand your and
 
 The company-wide tool for requesting absences is Bamboo. Aim to give as much notice for your absence as you reasonably can, as a rule of thumb: two weeks if you're away for less than two weeks, a month if longer.
 
-Currently we don't have a company-wide standard of recording limited availability due to travel, participation in workshops or events. However, there exist the following approaches adopted by some teams, which you should get acquainted with and use when working with that team:
+Currently we don't have a company-wide standard of recording limited availability due to travel, participation in workshops or events. We would like to propose one company standard, and two additional extras if this fits within your workflow. 
 
-## Bamboo "unavailable" option
+## Company Standard: Bamboo "unavailable" option
 
-If you are going to be working but mostly unavailable because you are travelling, in a client sprint or in a conference, please use the "unavailable" option in Bamboo to set those dates in advance. The process is the same as with time off requests.
+We already record all vacation absences in Bamboo. The who's out Calendar in Bamboo also lets you see, across the whole team, when people have planned abscences. You can use the iCal feed to import this list into Google Calendar, if you like to see it there too. 
+
+We'd also like to extend that to help us record other absences. If you are going to be working but mostly unavailable because you are travelling, in a client sprint or in a conference, please use the "unavailable" option in Bamboo to set those dates in advance. The process is the same as with time off requests.
 
 ![image](https://user-images.githubusercontent.com/1506306/42953516-eca834dc-8b7a-11e8-9d2d-1e897298be9c.png)
 
 ![image](https://user-images.githubusercontent.com/1506306/42953576-0b67b758-8b7b-11e8-9a01-0eb37edfbb48.png)
 
-## Teamweek
+Please note that the absences are not pulled through in the iCal feed: always use Bamboo as the primary source of who's in and who's out. 
 
-Record time-off using the "holiday" project and create projects for events you're taking part in. This is visible in the timeline in the same way as your project assignments.
+## Optional extra: Teamweek
+
+In some projects we use Teamweek to plan our work for weeks or months at a time. For these staff involved in planning, it can be useful that you also record your absences (vacation, working but mostly unavailable etc)  in Teamweek too, using the "holiday" project and create projects for events you're taking part in. This is visible in the timeline in the same way as your project assignments.
 
 ![image](https://user-images.githubusercontent.com/134055/43245679-11a73f22-90a7-11e8-9e56-5ef4e99d13ac.png)
 
-## Google Calendar Out of Office
+If your team is not using Teamweek for the projects you're working on, please don't feel like you have to use this. 
 
-You can mark yourself as Out of Office using Google Calendar. This means, whenever anyone is booking a meeting, they can automatically see that you are away. And when a client books a meeting with you, they will get an automatic reply telling them you are on vacation. 
+## Optional Extra: Google Calendar Out of Office
+
+Many of our clients use Calendar applications to arrange meetings or events. Using the Out of Office feature in Google Calendar can help improve the visibility of your absence to them when they arrange meetings.  
+
+When you mark yourself as Out of Office using Google Calendar, whenever anyone is booking a meeting with you when you are out, they will get an automatic reply telling them you are on not available. Where colleagues or clients have access to view your calendar, they can automatically see that you are unavailable.
 
 You can set this up by choosing the "out of office" option when creating a new event. Select the start/ end dates and write a decline message explaining when you will be back. 

--- a/guidelines/absences.md
+++ b/guidelines/absences.md
@@ -20,7 +20,7 @@ Please note that the absences are not pulled through in the iCal feed: always us
 
 ## Optional extra: Teamweek
 
-In some projects we use Teamweek to plan our work for weeks or months at a time. For these staff involved in planning, it can be useful that you also record your absences (vacation, working but mostly unavailable etc)  in Teamweek too, using the "holiday" project and create projects for events you're taking part in. This is visible in the timeline in the same way as your project assignments.
+In some projects we use Teamweek to plan our work for weeks or months at a time. For these staff involved in planning, it can be useful that you also record your absences in Teamweek too. You can use the "holiday" or "maternal/parental leave" project. If your absence is related to a specific project workshop or meeting, add the words "unavailable" into the task description (+ allocate 8 hours a day to the task) so people can differentiate it from regular project work. For non-project absences not covered by the above, you can create a new project; again, make sure to label it as unavailable time. This is visible in the timeline in the same way as your project assignments.
 
 ![image](https://user-images.githubusercontent.com/134055/43245679-11a73f22-90a7-11e8-9e56-5ef4e99d13ac.png)
 


### PR DESCRIPTION
In this PR I’ve changed a lot of the language of the absences guideline to reflect the comments in that branch. I’m suggesting Bamboo as the mandatory place where people declare their unavailability, and changed the Teamwork and Google Calendar sections to read as optional extras and the circumstances in which it’s useful to do this too…
As it was quite a lot of change I thought it better to do this as a new PR rather than a commit to the existing branch. Hope that's ok. See the whole new amended text below. Any blockers?

# Absences

Everyone affected by your absence needs to be able to easily understand your and others' availability. This is done by using tools which allow to record and access this information in one place.

The company-wide tool for requesting absences is Bamboo. Aim to give as much notice for your absence as you reasonably can, as a rule of thumb: two weeks if you're away for less than two weeks, a month if longer.

Currently we don't have a company-wide standard of recording limited availability due to travel, participation in workshops or events. We would like to propose one company standard, and two additional extras if this fits within your workflow. 

## Company Standard: Bamboo "unavailable" option

We already record all vacation absences in Bamboo. The who's out Calendar in Bamboo also lets you see, across the whole team, when people have planned abscences. You can use the iCal feed to import this list into Google Calendar, if you like to see it there too. 

We'd also like to extend that to help us record other absences. If you are going to be working but mostly unavailable because you are travelling, in a client sprint or in a conference, please use the "unavailable" option in Bamboo to set those dates in advance. The process is the same as with time off requests.

![image](https://user-images.githubusercontent.com/1506306/42953516-eca834dc-8b7a-11e8-9d2d-1e897298be9c.png)

![image](https://user-images.githubusercontent.com/1506306/42953576-0b67b758-8b7b-11e8-9a01-0eb37edfbb48.png)

Please note that the absences are not pulled through in the iCal feed: always use Bamboo as the primary source of who's in and who's out. 

## Optional extra: Teamweek

In some projects we use Teamweek to plan our work for weeks or months at a time. For these staff involved in planning, it can be useful that you also record your absences (vacation, working but mostly unavailable etc)  in Teamweek too, using the "holiday" project and create projects for events you're taking part in. This is visible in the timeline in the same way as your project assignments.

![image](https://user-images.githubusercontent.com/134055/43245679-11a73f22-90a7-11e8-9e56-5ef4e99d13ac.png)

If your team is not using Teamweek for the projects you're working on, please don't feel like you have to use this. 

## Optional Extra: Google Calendar Out of Office

Many of our clients use Calendar applications to arrange meetings or events. Using the Out of Office feature in Google Calendar can help improve the visibility of your absence to them when they arrange meetings.  

When you mark yourself as Out of Office using Google Calendar, whenever anyone is booking a meeting with you when you are out, they will get an automatic reply telling them you are on not available. Where colleagues or clients have access to view your calendar, they can automatically see that you are unavailable.

You can set this up by choosing the "out of office" option when creating a new event. Select the start/ end dates and write a decline message explaining when you will be back. 