### PR TITLE
Remove extended parental leave from the list

### DIFF
--- a/guidelines/benefits.md
+++ b/guidelines/benefits.md
@@ -8,7 +8,6 @@
 - 22 days of vacation (plus the bank holidays) and an additional one on your birthday.
 - Flexible schedules including the possibility of sporadic remote work.
 - Recruiting bonus. If you bring someone you know to the team and we hire them you get 1000 € after six months.
-- One extra month of paternity leave :baby:
 
 ## Specific by location
 
@@ -52,6 +51,10 @@ In the following table you can see the cost for you depending on the years you'v
 Extra family members: 38.36 €/month
 
 *these prices are valid as long as our plan includes more than 12 people
+
+Parents in Spain currently also receive one extra month of paternity leave, paid by the company. The motivation for this policy is the belief that men and women should be treated equally and have the same rights. We think that current laws in Spain, that give 5 weeks of  leave to men and 16 to women act as a negative factor to women, as they are less likely to be hired because of the law. This is why we consider this more of a policy than a benefit.
+
+For this reason, we currently do not implement the same policy in different countries with different laws and treat each independently, with the aim of correcting as much as we can the possible gender biases created by law.
 
 We are using [bamboo](https://vizzuality.bamboohr.co.uk/) to view all the benefits available so if you check the "Benefits" tab you should already see what plans you are eligible for. Please take a look and make sure it's correct according to your hire date.
 


### PR DESCRIPTION
The motivation for giving fathers an extra month of paternity leave in Spain came from the fact that laws in Spain give men 5 weeks and women 16 weeks, which has an effect of women being less competitive in the job market. By paying an extra month to men we aimed to correct this inequality, so for Vizzuality it's not more profitable or convenient to hire men or women, and thus remove the possible bias.

I thought it would be good to clarify the nature of this policy and make sure we are all on the same page about this, also figure out how this policy applies in different places and adapts as laws change.

My proposal, as a company-wide policy is that we try to correct biases when we detect them in each country's laws, not necessarily trying to make them equivalent across countries, but promoting equality within each.

I'd like to use this thread to discuss laws in Spain, UK, and Portugal and decide what our position should be in each country. After a first assessment, laws in Portugal seem to be very gender-balanced (http://www.cgtp.pt/igualdade/perguntas-frequentes/7584-direitos-de-maternidade-e-paternidade-parentalidade-0) so there may not be a need for this policy there. Laws in Spain are gradually getting better (with 8 weeks for men being approved this month and equality expected for next year). I haven't had a chance to study UK's laws.