### PR TITLE
How to organise a lightning talk

### DIFF
--- a/guidelines/lightning-talk.md
+++ b/guidelines/lightning-talk.md
@@ -1,0 +1,13 @@
+## Organising a Lightning Talk :zap:
+This guideline shows the steps to follow after you have decided to organise a lightning talk (i.e. it does not cover the steps to decide if you should give a lightning talk).
+As the organiser of a Lightning talk there are a few steps to follow to make sure it goes as you expect. 
+### 1. Scheduling the lightning talk
+It is up to you for how long you want to schedule the lightning talk. Once you know the time required for it, a strategy to make sure a large portion of Vizzuality can join the talk is to use the Spanish lunch time slot (2-3pm) and to avoid scheduling the talk on a Friday. 
+If you want to make sure certain people are available on the time slot you have in mind use the Google Calendar web app to see these people availability (they might be out of the office or in a full day workshop or it might be a bank holiday in one of the offices). 
+### 2. Sending the invites out
+Once you have decided on the time slot, use your calendar to send the invites to all. 
+### 3. Booking the meeting room in Madrid (optional)
+Even if you will be presenting remotely, you might wish to use the material from the meeting room in Madrid (TV and Owl). If so, follow the guidelines to book the meeting room.
+If you are not in Madrid, delegate on someone (and let them know) to set up the material on time. 
+### 4. Getting food for the Madrid office (optional)
+As the organiser it is your responsibility to decide if you will request food. Inform on your decision to order food for the lightning talk the previous day in the #madrizz channel. Three hours before to the start of the lightning talk inform Liuba or Laura of the number of people that will be attending to then order food. 

--- a/guidelines/lightning-talk.md
+++ b/guidelines/lightning-talk.md
@@ -1,8 +1,8 @@
 ## Organising a Brown Bag Talk 
-This guideline shows the steps to follow after you have decided to organise a lightning talk (i.e. it does not cover the steps to decide if you should give a lightning talk).
-As the organiser of a Lightning talk there are a few steps to follow to make sure it goes as you expect. 
-### 1. Scheduling the lightning talk
-It is up to you for how long you want to schedule the lightning talk. 
+This guideline shows the steps to follow after you have decided to organise a brown bag talk (i.e. it does not cover the steps to decide if you should give a brown bag talk).
+As the organiser of a brown bag talk there are a few steps to follow to make sure it goes as you expect. 
+### 1. Scheduling the brown bag talk
+It is up to you for how long you want to schedule the brown bag talk. 
 If you want to make sure certain people are available on the time slot you have in mind use the Google Calendar web app to see these people availability (they might be out of the office or in a full day workshop or it might be a bank holiday in one of the offices). 
 ### 2. Sending the invites out
 Once you have decided on the time slot, use your calendar to send the invites to all. 
@@ -10,4 +10,4 @@ Once you have decided on the time slot, use your calendar to send the invites to
 Even if you will be presenting remotely, you might wish to use the material from the meeting room in Madrid (TV and Owl). If so, follow the guidelines to book the meeting room.
 If you are not in Madrid, delegate on someone (and let them know) to set up the material on time. 
 ### 4. Getting food for the Madrid office (optional)
-If you have chosen to schedule the talk during the 2-3pm slot, as the organiser, it is your responsibility to decide if you will request food. Inform on your decision to order food for the lightning talk the previous day in the #madrizz channel. Three hours before to the start of the lightning talk inform Liuba or Laura of the number of people that will be attending to then order food. 
+If you have chosen to schedule the talk during the 2-3pm slot, as the organiser, it is your responsibility to decide if you will request food. Inform on your decision to order food for the brown bag talk the previous day in the #madrizz channel. Three hours before to the start of the brown bag talk inform Liuba or Laura of the number of people that will be attending to then order food. 

--- a/guidelines/lightning-talk.md
+++ b/guidelines/lightning-talk.md
@@ -2,7 +2,7 @@
 This guideline shows the steps to follow after you have decided to organise a lightning talk (i.e. it does not cover the steps to decide if you should give a lightning talk).
 As the organiser of a Lightning talk there are a few steps to follow to make sure it goes as you expect. 
 ### 1. Scheduling the lightning talk
-It is up to you for how long you want to schedule the lightning talk. Once you know the time required for it, a strategy to make sure a large portion of Vizzuality can join the talk is to use the Spanish lunch time slot (2-3pm) and to avoid scheduling the talk on a Friday. 
+It is up to you for how long you want to schedule the lightning talk. 
 If you want to make sure certain people are available on the time slot you have in mind use the Google Calendar web app to see these people availability (they might be out of the office or in a full day workshop or it might be a bank holiday in one of the offices). 
 ### 2. Sending the invites out
 Once you have decided on the time slot, use your calendar to send the invites to all. 
@@ -10,4 +10,4 @@ Once you have decided on the time slot, use your calendar to send the invites to
 Even if you will be presenting remotely, you might wish to use the material from the meeting room in Madrid (TV and Owl). If so, follow the guidelines to book the meeting room.
 If you are not in Madrid, delegate on someone (and let them know) to set up the material on time. 
 ### 4. Getting food for the Madrid office (optional)
-As the organiser it is your responsibility to decide if you will request food. Inform on your decision to order food for the lightning talk the previous day in the #madrizz channel. Three hours before to the start of the lightning talk inform Liuba or Laura of the number of people that will be attending to then order food. 
+If you have chosen to schedule the talk during the 2-3pm slot, as the organiser, it is your responsibility to decide if you will request food. Inform on your decision to order food for the lightning talk the previous day in the #madrizz channel. Three hours before to the start of the lightning talk inform Liuba or Laura of the number of people that will be attending to then order food. 

--- a/guidelines/lightning-talk.md
+++ b/guidelines/lightning-talk.md
@@ -1,4 +1,4 @@
-## Organising a Lightning Talk :zap:
+## Organising a Brown Bag Talk 
 This guideline shows the steps to follow after you have decided to organise a lightning talk (i.e. it does not cover the steps to decide if you should give a lightning talk).
 As the organiser of a Lightning talk there are a few steps to follow to make sure it goes as you expect. 
 ### 1. Scheduling the lightning talk


### PR DESCRIPTION
This guideline shows the steps to follow after it has been decided to organise a lightning talk (i.e. it does not cover the steps to decide if a lightning talk should be organised).